### PR TITLE
INTERLOK-3835

### DIFF
--- a/src/main/java/com/adaptris/core/jms/wmq/AdvancedMqSeriesImplementation.java
+++ b/src/main/java/com/adaptris/core/jms/wmq/AdvancedMqSeriesImplementation.java
@@ -318,6 +318,16 @@ public class AdvancedMqSeriesImplementation extends VendorImplementationImp {
       }
     },
     /**
+     * Invokes {@link MQConnectionFactory#setClientReconnectOptions(WMQConstants.WMQ_CLIENT_RECONNECT_DISABLED)}
+     */
+    DisableClientReconnectOptions {
+      @Override
+      void applyProperty(MQConnectionFactory cf, String s) throws JMSException {
+        if(Boolean.getBoolean(s))
+          cf.setClientReconnectOptions(WMQConstants.WMQ_CLIENT_RECONNECT_DISABLED);
+      }
+    },
+    /**
      * Invokes {@link MQConnectionFactory#setDescription(String)}
      *
      */

--- a/src/main/java/com/adaptris/core/jms/wmq/BasicMqSeriesImplementation.java
+++ b/src/main/java/com/adaptris/core/jms/wmq/BasicMqSeriesImplementation.java
@@ -143,6 +143,7 @@ public class BasicMqSeriesImplementation extends VendorImplementationImp {
   @NotBlank
   @AutoPopulated
   @Pattern(regexp = "MQJMS_TP_BINDINGS_MQ|MQJMS_TP_CLIENT_MQ_TCPIP|MQJMS_TP_DIRECT_TCPIP|MQJMS_TP_DIRECT_HTTP|[0-9]+")
+  @InputFieldDefault(value="MQJMS_TP_CLIENT_MQ_TCPIP")
   private String transportType;
   private String queueManager;
   private String channel;
@@ -318,6 +319,10 @@ public class BasicMqSeriesImplementation extends VendorImplementationImp {
     return brokerHost;
   }
 
+  /**
+   * Sets the host name or IP address of the brokers host.
+   * @param brokerHost
+   */
   public void setBrokerHost(String brokerHost) {
     this.brokerHost = brokerHost;
   }
@@ -326,6 +331,10 @@ public class BasicMqSeriesImplementation extends VendorImplementationImp {
     return brokerPort;
   }
 
+  /**
+   * Sets the port number of the brokers host.
+   * @param brokerHost
+   */
   public void setBrokerPort(int port) {
     brokerPort = port;
   }

--- a/src/main/java/com/adaptris/core/jms/wmq/BasicMqSeriesImplementation.java
+++ b/src/main/java/com/adaptris/core/jms/wmq/BasicMqSeriesImplementation.java
@@ -4,12 +4,16 @@ import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
+
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.jms.VendorImplementationBase;
 import com.adaptris.core.jms.VendorImplementationImp;
 import com.ibm.mq.jms.MQConnectionFactory;
+import com.ibm.msg.client.wmq.WMQConstants;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -143,6 +147,8 @@ public class BasicMqSeriesImplementation extends VendorImplementationImp {
   private String queueManager;
   private String channel;
   private String temporaryModel; // nb PTP only
+  @InputFieldDefault(value="false")
+  private Boolean disableClientReconnect;
   @NotBlank
   private String brokerHost;
   private int brokerPort;
@@ -189,6 +195,10 @@ public class BasicMqSeriesImplementation extends VendorImplementationImp {
 
     if (getTemporaryModel() != null) {
       result.setTemporaryModel(getTemporaryModel());
+    }
+    
+    if(disableClientReconnect()) {
+      result.setClientReconnectOptions(WMQConstants.WMQ_CLIENT_RECONNECT_DISABLED);
     }
 
     return result;
@@ -318,6 +328,22 @@ public class BasicMqSeriesImplementation extends VendorImplementationImp {
 
   public void setBrokerPort(int port) {
     brokerPort = port;
+  }
+
+  public Boolean getDisableClientReconnect() {
+    return disableClientReconnect;
+  }
+
+  /**
+   * Will disable WMQ client reconnect handling.
+   * @param disableClientReconnect
+   */
+  public void setDisableClientReconnect(Boolean disableClientReconnect) {
+    this.disableClientReconnect = disableClientReconnect;
+  }
+  
+  protected boolean disableClientReconnect() {
+    return BooleanUtils.toBooleanDefaultIfNull(getDisableClientReconnect(), false);
   }
 
   @Override

--- a/src/test/java/com/adaptris/core/jms/wmq/AdvancedMqSeriesProducerTest.java
+++ b/src/test/java/com/adaptris/core/jms/wmq/AdvancedMqSeriesProducerTest.java
@@ -70,6 +70,8 @@ public class AdvancedMqSeriesProducerTest extends JmsProducerExample {
         .name()));
     cp.add(new KeyValuePair(ConnectionFactoryProperty.HostName.name(), "localhost"));
     cp.add(new KeyValuePair(ConnectionFactoryProperty.Port.name(), "1414"));
+    cp.add(new KeyValuePair(ConnectionFactoryProperty.DisableClientReconnectOptions.name(), "true"));
+    
     mq.getSessionProperties().add(new MqSessionProperty("OptimisticPublication", "true", "Boolean"));
     return mq;
   }

--- a/src/test/java/com/adaptris/core/jms/wmq/BasicMqSeriesProducerTest.java
+++ b/src/test/java/com/adaptris/core/jms/wmq/BasicMqSeriesProducerTest.java
@@ -36,6 +36,7 @@ public class BasicMqSeriesProducerTest extends JmsProducerExample {
     mq.setChannel("MyChannel");
     mq.setBrokerHost("localhost");
     mq.setBrokerPort(1414);
+    mq.setDisableClientReconnect(true);
     c.setVendorImplementation(mq);
     c.setWorkersFirstOnShutdown(true);
     c.setConnectionErrorHandler(new JmsConnectionErrorHandler());


### PR DESCRIPTION
## Motivation

In almost all cases we want Interlok to handle client reconnecting rather than the client libraries.  Therefore we need the ability to turn client reconnection handling off for the WMQ client library.

## Modification

A simple change to both the basic and advanced impls.

The basic now has a new boolean class property that will in the background set MQConnectionFactory.setClientReconnectOptions(WMQConstants.WMQ_CLIENT_RECONNECT_DISABLED);

The advanced impl has had another connection factory enum item added for the same reason.

The default value for both is false.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like XStreamAlias / ComponentProfile)
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

You can now turn off WMQ client reconnect handling for the connection factories created by both the basic and advanced ikmpls.

## Testing


