### PR TITLE
INTERLOK-4477: Upgrade jakarta/Update release version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ plugins {
 }
 
 ext {
-  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.0-SNAPSHOT'
-  releaseVersion = project.findProperty('releaseVersion') ?: '5.0-SNAPSHOT'
+  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.1-SNAPSHOT'
+  releaseVersion = project.findProperty('releaseVersion') ?: '5.1-SNAPSHOT'
   nexusBaseUrl = project.findProperty('nexusBaseUrl') ?: 'https://nexus.adaptris.net/nexus'
   mavenPublishUrl = project.findProperty('mavenPublishUrl') ?: nexusBaseUrl + '/content/repositories/snapshots'
   javadocsBaseUrl = nexusBaseUrl + "/content/sites/javadocs/com/adaptris"
@@ -160,7 +160,7 @@ configurations {
   all*.exclude group: 'org.eclipse.jetty.orbit', module: 'javax.mail.glassfish'
   // INTERLOK-3197 exclude old javax.mail
   all*.exclude group: 'com.sun.mail', module: 'javax.mail'
-  all*.exclude group: 'javax.validation', module: 'validation-api'
+  all*.exclude group: 'jakarta.validation', module: 'validation-api'
   all*.exclude group: 'javax.activation', module: 'activation'
   all*.exclude group: 'javax.activation', module: 'javax.activation-api'
 
@@ -178,12 +178,13 @@ dependencies {
 
   implementation ("org.slf4j:slf4j-api:$slf4jVersion")
   implementation ("org.slf4j:jcl-over-slf4j:$slf4jVersion")
-  implementation ("com.ibm.mq:com.ibm.mq.allclient:$mqVersion") {
+  implementation ("com.ibm.mq:com.ibm.mq.jakarta.client:$mqVersion") {
     exclude group: "org.json", module: "json"
   }
   implementation ("org.json:json:$jsonOrgVersion")
-  implementation "org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1.1", optional
-  implementation "org.apache.geronimo.specs:geronimo-j2ee-connector_1.6_spec:1.0", optional
+  api ("jakarta.jms:jakarta.jms-api:3.1.0")
+  //implementation "org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1.1", optional
+//  implementation "org.apache.geronimo.specs:geronimo-j2ee-connector_1.6_spec:1.0", optional
 
   annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion") {changing= true}
   umlDoclet("nl.talsmasoftware:umldoclet:2.1.0")

--- a/src/main/java/com/adaptris/core/jms/wmq/AdvancedMqSeriesImplementation.java
+++ b/src/main/java/com/adaptris/core/jms/wmq/AdvancedMqSeriesImplementation.java
@@ -5,9 +5,9 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.jms.ConnectionFactory;
-import javax.jms.JMSException;
-import javax.validation.constraints.NotNull;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSException;
+import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
@@ -17,10 +17,10 @@ import com.adaptris.core.jms.VendorImplementationImp;
 import com.adaptris.core.metadata.MetadataFilter;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
-import com.ibm.mq.jms.MQConnectionFactory;
-import com.ibm.mq.jms.MQQueueConnectionFactory;
-import com.ibm.mq.jms.MQSession;
-import com.ibm.msg.client.wmq.WMQConstants;
+import com.ibm.mq.jakarta.jms.MQConnectionFactory;
+import com.ibm.mq.jakarta.jms.MQQueueConnectionFactory;
+import com.ibm.mq.jakarta.jms.MQSession;
+import com.ibm.msg.client.jakarta.wmq.WMQConstants;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -51,7 +51,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * </code> would call {@link MQConnectionFactory#setSendExitInit(String)}.
  * </p>
  * <p>
- * This vendor implementation also overrides {@link VendorImplementationImp#applyVendorSessionProperties(javax.jms.Session)} so that
+ * This vendor implementation also overrides {@link VendorImplementationImp#applyVendorSessionProperties(jakarta.jms.Session)} so that
  * specific MQ session properties can be applied. The way of doing this is to supply a list of mq-session-properties, which includes the
  * property name, value and data-type of the value.  You will need to consult your WebsphereMQ documentation or support team for a list of
  * available properties.
@@ -95,7 +95,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <p>
  * More generally speaking, the more powerful form of specifying a destination using uniform resource identifiers (URIs) is
  * preferred. This form allows you to specify remote queues (queues on a queue manager other than the one to which you are
- * connected). It also allows you to set the other properties contained in a com.ibm.mq.jms.MQQueue object. The URI for a queue
+ * connected). It also allows you to set the other properties contained in a com.ibm.mq.jakarta.jms.MQQueue object. The URI for a queue
  * begins with the sequence queue://, followed by the name of the queue manager on which the queue resides. This is followed by a
  * further /, the name of the queue, and optionally, a list of name-value pairs that set the remaining Queue properties. For
  * example: <strong>queue://Some_Other_Queue_Manager/SampleQ1?key1=value1&amp;key2=value2</strong>. If you don't specify a queue manager
@@ -155,7 +155,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @config advanced-mq-series-implementation
  * @license BASIC
  *
- * @see com.ibm.mq.jms.MQConnectionFactory
+ * @see com.ibm.mq.jakarta.jms.MQConnectionFactory
  */
 @XStreamAlias("advanced-mq-series-implementation")
 public class AdvancedMqSeriesImplementation extends VendorImplementationImp {
@@ -709,10 +709,10 @@ public class AdvancedMqSeriesImplementation extends VendorImplementationImp {
 
   /**
    *
-   * @see VendorImplementationImp#applyVendorSessionProperties(javax.jms.Session)
+   * @see VendorImplementationImp#applyVendorSessionProperties(jakarta.jms.Session)
    */
   @Override
-  public void applyVendorSessionProperties(javax.jms.Session s) throws JMSException {
+  public void applyVendorSessionProperties(jakarta.jms.Session s) throws JMSException {
     for(MqSessionProperty sessionProp : getSessionProperties()) {
       SessionPropertyDataType.valueOf(sessionProp.getDataType().toUpperCase()).applyProperty((MQSession) s, sessionProp.getPropertyName(), sessionProp.getPropertyName());
     }

--- a/src/main/java/com/adaptris/core/jms/wmq/BasicMqSeriesImplementation.java
+++ b/src/main/java/com/adaptris/core/jms/wmq/BasicMqSeriesImplementation.java
@@ -1,9 +1,9 @@
 package com.adaptris.core.jms.wmq;
 
-import javax.jms.ConnectionFactory;
-import javax.jms.JMSException;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSException;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -13,8 +13,8 @@ import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.jms.VendorImplementationBase;
 import com.adaptris.core.jms.VendorImplementationImp;
 import com.adaptris.core.metadata.MetadataFilter;
-import com.ibm.mq.jms.MQConnectionFactory;
-import com.ibm.msg.client.wmq.WMQConstants;
+import com.ibm.mq.jakarta.jms.MQConnectionFactory;
+import com.ibm.msg.client.jakarta.wmq.WMQConstants;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -79,7 +79,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <p>
  * More generally speaking, the more powerful form of specifying a destination using uniform resource identifiers (URIs) is
  * preferred. This form allows you to specify remote queues (queues on a queue manager other than the one to which you are
- * connected). It also allows you to set the other properties contained in a com.ibm.mq.jms.MQQueue object. The URI for a queue
+ * connected). It also allows you to set the other properties contained in a com.ibm.mq.jakarta.jms.MQQueue object. The URI for a queue
  * begins with the sequence queue://, followed by the name of the queue manager on which the queue resides. This is followed by a
  * further /, the name of the queue, and optionally, a list of name-value pairs that set the remaining Queue properties. For
  * example: <strong>queue://Some_Other_Queue_Manager/SampleQ1?key1=value1&amp;key2=value2</strong>. If you don't specify a queue manager

--- a/src/main/java/com/adaptris/core/jms/wmq/MqSessionProperty.java
+++ b/src/main/java/com/adaptris/core/jms/wmq/MqSessionProperty.java
@@ -1,8 +1,8 @@
 package com.adaptris.core.jms.wmq;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 

--- a/src/main/java/com/adaptris/core/jms/wmq/TransportTypeHelper.java
+++ b/src/main/java/com/adaptris/core/jms/wmq/TransportTypeHelper.java
@@ -1,6 +1,6 @@
 package com.adaptris.core.jms.wmq;
 
-import com.ibm.msg.client.wmq.WMQConstants;
+import com.ibm.msg.client.jakarta.wmq.WMQConstants;
 
 public class TransportTypeHelper {
 

--- a/src/main/java/com/adaptris/core/jms/wmq/package-info.java
+++ b/src/main/java/com/adaptris/core/jms/wmq/package-info.java
@@ -8,7 +8,7 @@
   <p>If this property is set, all exceptions resulting from a broken
     connection are sent to the exception listener, regardless of the
     context in which they occur. If this is not set, then broken
-    connections may not trigger the standard javax.jms.ExceptionListener
+    connections may not trigger the standard jakarta.jms.ExceptionListener
     interface which means the adapter is not notified of a broken
     connection to WebsphereMQ and subsequently cannot recover from a
     broken connection to WebsphereMQ.</p>
@@ -51,7 +51,7 @@
 		destination using uniform resource identifiers (URIs) is preferred.
 		This form allows you to specify remote queues (queues on a queue
 		manager other than the one to which you are connected). It also allows
-		you to set the other properties contained in a com.ibm.mq.jms.MQQueue
+		you to set the other properties contained in a com.ibm.mq.jakarta.jms.MQQueue
 		object. The URI for a queue begins with the sequence queue://,
 		followed by the name of the queue manager on which the queue resides.
 		This is followed by a further /, the name of the queue, and

--- a/src/test/java/com/adaptris/core/jms/wmq/AdvancedMqSeriesProducerTest.java
+++ b/src/test/java/com/adaptris/core/jms/wmq/AdvancedMqSeriesProducerTest.java
@@ -24,7 +24,7 @@ public class AdvancedMqSeriesProducerTest extends JmsProducerExample {
       + "\n\nIf this property is set, all exceptions resulting from a broken connection"
       + "\nare sent to the exception listener, regardless of the context in which they"
       + "\noccur. If this is not set, then broken connections may not trigger the"
-      + "\nstandard javax.jms.ExceptionListener interface which means the adapter"
+      + "\nstandard jakarta.jms.ExceptionListener interface which means the adapter"
       + "\nis not notified of a broken connection to WebsphereMQ and subsequently"
       + "\ncannot recover from a broken connection to WebsphereMQ" + "\n-->\n";
 


### PR DESCRIPTION
## Motivation

INTERLOK-4477: Upgrade jakarta and jetty, make release version 5.1-SNAPSHOT

## Modification
Updated necessary dependencies and imports to use jakarta instead of javax


## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Compatibility with future versions of jakarta/jetty

## Testing


